### PR TITLE
feat(renovate): create monorepojs config preset

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-present, Pure Auto LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "name": "@monorepojs/core",
   "workspaces": [
     "apps/*",
     "packages/*",
@@ -22,9 +21,6 @@
     "test": "lerna run test",
     "test:coverage": "lerna run test:coverage --stream --concurrency 1"
   },
-  "repository": "https://github.com/monorepojs/monorepojs.git",
-  "author": "Jordan Carroll <jordanc@purecars.com>",
-  "license": "MIT",
   "devDependencies": {
     "commitizen": "3.0.5",
     "cz-conventional-changelog": "2.1.0",

--- a/packages/monorepo-renovate-config/LICENSE
+++ b/packages/monorepo-renovate-config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-present, Pure Auto LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/monorepo-renovate-config/README.md
+++ b/packages/monorepo-renovate-config/README.md
@@ -1,0 +1,13 @@
+# @monorepojs Renovate Preset
+
+This directory contains the renovate config preset for the `@monorepojs` monorepo.
+
+It can be used by appending `@monorepojs` to the `extends` option in your `renovate` config. For example:
+
+```json
+{
+  "extends": ["config:base", "@monorepojs"]
+}
+```
+
+This preset ensures that dependencies from the `@monorepojs` monorepo will be upgraded at the same time (in same branch/PR).

--- a/packages/monorepo-renovate-config/package.json
+++ b/packages/monorepo-renovate-config/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@monorepojs/renovate-config",
+  "version": "0.0.1",
+  "description": "Preset monorepojs config for Renovate",
+  "repository": "monorepojs/monorepojs",
+  "homepage": "https://github.com/monorepojs/monorepojs/packages/monorepo-renovate-config",
+  "license": "MIT",
+  "engines": {
+    "node": ">=6"
+  },
+  "bugs": {
+    "url": "https://github.com/monorepojs/monorepojs/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "renovate-config": {
+    "default": {
+      "description": "monorepojs monorepo",
+      "packagePatterns": [
+        "^@monorepojs/"
+      ]
+    }
+  }
+}

--- a/packages/monorepo-scripts/LICENSE
+++ b/packages/monorepo-scripts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-present, Pure Auto LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/monorepo-scripts/package.json
+++ b/packages/monorepo-scripts/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@monorepojs/scripts",
   "version": "0.2.1",
+  "description": "Configuration and scripts for MonorepoJS",
+  "repository": "monorepojs/monorepojs",
+  "homepage": "https://monorepo-documentation.firebaseapp.com/docs/packages/monorepo-scripts/",
+  "license": "MIT",
   "engines": {
     "node": ">=6"
+  },
+  "bugs": {
+    "url": "https://github.com/monorepojs/monorepojs/issues"
   },
   "files": [
     "bin",
@@ -10,8 +17,15 @@
     "scripts",
     "utils"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "monorepo-scripts": "./bin/monorepo-scripts.js"
+  },
+  "scripts": {
+    "lint": "monorepo-tools lint .",
+    "pre-commit": "monorepo-tools pre-commit"
   },
   "dependencies": {
     "@babel/core": "7.2.2",
@@ -71,15 +85,8 @@
     "react": "16.7.0",
     "react-dom": "16.7.0"
   },
-  "scripts": {
-    "lint": "monorepo-tools lint .",
-    "pre-commit": "monorepo-tools pre-commit"
-  },
   "optionalDependencies": {
     "fsevents": "2.0.1"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/monorepo-tools/LICENSE
+++ b/packages/monorepo-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-present, Pure Auto LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/monorepo-tools/package.json
+++ b/packages/monorepo-tools/package.json
@@ -1,6 +1,32 @@
 {
   "name": "@monorepojs/tools",
   "version": "0.1.1",
+  "description": "Opinionated developer tooling for MonorepoJS",
+  "repository": "monorepojs/monorepojs",
+  "homepage": "https://monorepo-documentation.firebaseapp.com/docs/packages/monorepo-tools/",
+  "license": "MIT",
+  "engines": {
+    "node": ">=6"
+  },
+  "bugs": {
+    "url": "https://github.com/monorepojs/monorepojs/issues"
+  },
+  "files": [
+    "tools.sh",
+    "utils",
+    "eslint-config",
+    "prettier-config"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "monorepo-tools": "./tools.sh"
+  },
+  "scripts": {
+    "lint": "eslint ./ --fix -c ./eslint-config/node.js",
+    "pre-commit": "lint-staged"
+  },
   "dependencies": {
     "babel-eslint": "10.0.1",
     "eslint": "5.12.0",
@@ -13,22 +39,6 @@
     "eslint-plugin-react": "7.12.3",
     "lint-staged": "8.1.0",
     "prettier": "1.15.3"
-  },
-  "scripts": {
-    "lint": "eslint ./ --fix -c ./eslint-config/node.js",
-    "pre-commit": "lint-staged"
-  },
-  "files": [
-    "tools.sh",
-    "utils",
-    "eslint-config",
-    "prettier-config"
-  ],
-  "bin": {
-    "monorepo-tools": "./tools.sh"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
Creates a new renovate config preset package that can be used to ensure that dependencies from the `@monorepojs` monorepo will be upgraded at the same time (in same branch/PR).

Also cleans up `package.json` files and adds the MIT license to each package.