### PR TITLE
feat(support for npm aliases): allows the .monorepo.yml file to provide an alias

### DIFF
--- a/packages/monorepo-scripts/config/mono.js
+++ b/packages/monorepo-scripts/config/mono.js
@@ -98,10 +98,20 @@ const findPkgs = (rootPath, globPatterns) => {
  */
 function getPkgsAliases(allPkgs, allSrcPkgs) {
   return allPkgs.reduce((aliases, pkgPath) => {
-    const { name, src, lib } = getMonorepoConfig(pkgPath)
+    const { alias, name, src, lib } = getMonorepoConfig(pkgPath)
     const isSrcPkg = allSrcPkgs.includes(pkgPath)
     const target = isSrcPkg ? src : lib
     const pkgAlias = path.join(name, target)
+
+    if (alias) {
+      console.log(
+        'monorepojs: package',
+        name,
+        'is aliased as',
+        alias,
+        'and must be imported using the alias from all code'
+      )
+    }
 
     if (isEnvTest) {
       /**
@@ -110,12 +120,11 @@ function getPkgsAliases(allPkgs, allSrcPkgs) {
        * capture everything after the name (in the capture group) then
        * we want to pass it the capture group to the end of the transformation.
        */
-      aliases[`^${name.replace('/', '/')}($|/.*)`] = `${pkgAlias.replace(
-        '/',
-        '/'
-      )}$1`
+      aliases[
+        `^${(alias || name).replace('/', '/')}($|/.*)`
+      ] = `${pkgAlias.replace('/', '/')}$1`
     } else {
-      aliases[name] = pkgAlias
+      aliases[alias || name] = pkgAlias
     }
     return aliases
   }, {})

--- a/packages/monorepo-scripts/package.json
+++ b/packages/monorepo-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepojs/scripts",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Configuration and scripts for MonorepoJS",
   "repository": "monorepojs/monorepojs",
   "homepage": "https://monorepo-documentation.firebaseapp.com/docs/packages/monorepo-scripts/",


### PR DESCRIPTION
Hey folks.  We are trying to push private packages from Signal for consumption outside of Signal.   However, we can only publish to the @purecarslabs groupname not to the @signal groupname which most signal packages use.   Rather than a giant search-and-replace of @signal with @purecarslabs, we want to try to use yarn aliases (https://classic.yarnpkg.com/en/docs/cli/add/, see the section on "alias packages") so we can continue to import the packages we want to push under the @purecaslabs name without needing to change all the imports across the whole project.

There are some gotchas to making this work.   One of those is that we need monorepojs to look for an alias name in `.monorepo.yml` and use it instead of the native package name when creating webpack aliases, so that we can continue to get the correct `lib` folder contents for packages which are imported and aliased in this manner.

Thanks!

BTW, here is a `.monorepo.yml` containing this aliasing:

```
alias: "@signal/analytics"
src: src
lib: lib
srcWorkspaces:
  - packages/*
env:
  production:
    srcWorkspaces: []
```

This alias is needed because we changed the `package.json` for that package to use a `@purecarslabs` name, so that we can publish it:

```
{
  "name": "@purecarslabs/signal-analytics",
  "version": "1.14.0-test3",
  "description": "Analytics utils",
  "engines": {
    "node": "10.17.0"
  },
  "repository": "PureCarsLabs/signal",
  "scripts": {
    "lint": "monorepo-tools lint ./src",
    "pre-commit": "monorepo-tools pre-commit .",
    "build": "babel src --out-dir lib --copy-files",
    "clean": "rimraf lib"
  },
  "dependencies": {
    "@purecarslabs/redux-segment": "1.6.3",
    "react-redux": "7.1.3",
    "redux-act": "1.7.7"
  },
  "peerDependencies": {
    "react": "^0.0.0-experimental-b53ea6ca0"
  }
}
```

Finally, in case you are curious, here is what the import of that analytics package now looks like from @signal/desktop:

```
  "dependencies": {
    ...
    "@signal/analytics": "npm:@purecarslabs/signal-analytics",
    ...
  }

```